### PR TITLE
Update to deal with incorrect group assignment

### DIFF
--- a/Intune/RBAC/DeviceScopeTags/AddDeviceToGroupBasedOnPrimaryUserGroupMembership.ps1
+++ b/Intune/RBAC/DeviceScopeTags/AddDeviceToGroupBasedOnPrimaryUserGroupMembership.ps1
@@ -654,7 +654,7 @@ foreach ($device in $devices) {
             foreach ($cachedGroup in $cachedUserGroupMemberships) {
                 IF ($cachedGroup.userid -eq $PrimaryUser) {
                     write-verbose "`tusing user group membership cache for user $($PrimaryUser)"
-                    $userGroupMemerships=$cachedGroup.Groups
+                    $userGroupMemership=$cachedGroup.Groups
                 }
             }
         } else {


### PR DESCRIPTION
Incorrect variable name used. Updated to fix issue with incorrect groups being used for some users.