### PR TITLE
Create the event source outside the if statement

### DIFF
--- a/Intune/Windows/OneDrivePerMachineSetup/OneDrivePerMachineSetup.ps1
+++ b/Intune/Windows/OneDrivePerMachineSetup/OneDrivePerMachineSetup.ps1
@@ -1,15 +1,17 @@
 $ScriptName="OneDriveSetupMachineInstall.ps1"
 
+#variables
+$eventSource = "My Scripts"
+
+#create an event log source to store the events
+New-EventLog -LogName Application -Source $eventSource -ErrorAction Ignore
+
 #check if onedrive machine setup is already installed
 If (-not (get-itempropertyvalue -PATH "hklm:\SOFTWARE\Microsoft\OneDrive\" -NAME "CurrentVersionPath" -ErrorAction SilentlyContinue)) {
 
-    #variables
+    #more variables
     $downloadURL="https://go.microsoft.com/fwlink/?linkid=844652"
     $outputfile="$env:temp\OneDriveSetup.exe"
-    $eventSource = "My Scripts"
-
-    #create an event log source to store the events
-    New-EventLog -LogName Application -Source $eventSource -ErrorAction Ignore
 
     #download the file
     Write-EventLog -LogName Application -Source $eventSource -EntryType Information -EventId 3 -message "$ScriptName : downloading from $downloadURL to $outputfile"


### PR DESCRIPTION
If testing this script interactively, the `if` statement to check for the non-existence of `hklm:\SOFTWARE\Microsoft\OneDrive\` may return false if OneDrive is already installed. In this case, we will try and log with `Write-EventLog` to an event source that has potentially not been created. Additionally, the `$eventSource` variable will not have been set, so `Write-EventLog` for _"OneDrive already installed per-machine"_ will always fail.

This pull request moves the creation of the event source and the definition of `$eventSource` so that writing to the event log will succeed in the case that OneDrive is already installed.

(Note that this issue does not occur if deployed with the suggested detection method, as the script will not be run at all! This does, however, improve usability when testing the script interactively.)

